### PR TITLE
Fixing phone notification parsing and config

### DIFF
--- a/gencon-hotels-lite.py
+++ b/gencon-hotels-lite.py
@@ -30,7 +30,7 @@ while True:
         hotel_room_objects = modules.filter_hotel_room_objects(hotel_room_objects, gchotels_config)
         if (gchotels_config.alerts_email or gchotels_config.alerts_sms or gchotels_config.alerts_twitter) \
                 and hotel_room_objects:
-            modules.send_alerts(hotel_room_objects, config)
+            modules.send_alerts(hotel_room_objects, gchotels_config)
             alerts_triggered = 1
         modules.clear()
         print(modules.table_creation(hotel_room_objects))

--- a/modules/config.py
+++ b/modules/config.py
@@ -1,5 +1,10 @@
 import modules
 
+#takes a comma sperated list and returns each item in an array with all
+#whitespace removed
+def to_comma_delimited_list(str):
+    items = str.split(',')
+    return list(map(lambda x: x.strip(),items))
 
 class Configuration(object):
     event_id = ""
@@ -31,11 +36,11 @@ def create_config_object(config):
     if gchotels_config.filter_room:
         gchotels_config.filter_room_include = (config["search-filters"])["hotel-room-filter-include"]
         gchotels_config.filter_room_exclude = (config["search-filters"])["hotel-room-filter-exclude"]
-    gchotels_config.alerts_email = modules.string_to_bool((config["alerts-config"])["send-email"])
+    gchotels_config.alerts_email = modules.string_to_bool(config["alerts-config"]["send-email"])
     if gchotels_config.alerts_email:
         gchotels_config.email_from_user = (config["email-send-config"])["from-user"]
         gchotels_config.email_from_password = (config["email-send-config"])["from-password"]
-        gchotels_config.email_send_to = (config["email-send-config"])["send-to"]
+        gchotels_config.email_send_to = to_comma_delimited_list(config["email-send-config"]["send-to"])
         gchotels_config.email_smtp_server = (config["email-send-config"])["smtp-server"]
         gchotels_config.email_smtp_port = (config["email-send-config"])["smtp-port"]
     gchotels_config.alerts_sms = modules.string_to_bool((config["alerts-config"])["send-sms"])
@@ -43,7 +48,7 @@ def create_config_object(config):
         gchotels_config.sms_twilio_sid = (config["sms-send-config"])["twilio-account-sid"]
         gchotels_config.sms_twilio_auth = (config["sms-send-config"])["twilio-account-auth"]
         gchotels_config.sms_from_number = (config["sms-send-config"])["from-number"]
-        gchotels_config.sms_to_numbers = (config["sms-send-config"])["to-numbers"]
+        gchotels_config.sms_to_numbers = to_comma_delimited_list(config["sms-send-config"]["to-numbers"])
     gchotels_config.alerts_twitter = modules.string_to_bool((config["alerts-config"])["send-twitter"])
     if gchotels_config.alerts_twitter:
         gchotels_config.twitter_consumer_key = (config["twitter-send-config"])["twitter-consumer-key"]


### PR DESCRIPTION
The Config parser was reading to-numbers as a string instead of a list as documented in the README. To fix this I created a parsing function that will convert the phone numbers into an array of numbers using commas as the delimiter.

Also tangentially, we were passing the config parser instead of the config object to send_alerts, which was causing a crash.

This should not cause any breaking changes, however I have not regenerated the .exe as I am on an OSX machine and do not know the steps to do so.